### PR TITLE
refactor(types): centralize CommandType and fix SequenceTask.action typing

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -8,8 +8,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useRobotStore } from "@/store/useRobotStore";
 import { useMutation } from "@tanstack/react-query";
 import { sendCommand } from "@/services/robotApi";
-import type { CommandType } from "@/services/robotApi";
-import type { RobotOperationalStatus } from "@/types";
+import type { CommandType, RobotOperationalStatus } from "@/types";
 
 export const ControlPanel = () => {
   const { toast } = useToast();

--- a/src/services/robotApi.ts
+++ b/src/services/robotApi.ts
@@ -1,4 +1,4 @@
-import type { RobotStatus } from "@/types";
+import type { RobotStatus, RobotCommand, CommandType } from "@/types";
 
 const BRIDGE = import.meta.env.VITE_BRIDGE_URL ?? "http://localhost:8000";
 
@@ -11,20 +11,6 @@ export const fetchRobotStatus = async (): Promise<RobotStatus> => {
 };
 
 // ── Commands ──────────────────────────────────────────────────────────────────
-
-export type CommandType =
-  | "move_forward"
-  | "move_backward"
-  | "move_left"
-  | "move_right"
-  | "move_up"
-  | "move_down"
-  | "rotate_left"
-  | "rotate_right"
-  | "stop"
-  | "go_home"
-  | "gripper_open"
-  | "gripper_close";
 
 export const sendCommand = async (
   type: CommandType,
@@ -44,7 +30,7 @@ export const sendCommand = async (
 // ── Sequences ─────────────────────────────────────────────────────────────────
 
 export interface SequenceTask {
-  action: string;
+  action: RobotCommand;
   duration: number;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,20 @@
 export type RobotConnectionStatus = "connected" | "disconnected" | "connecting";
 
+// Direct control commands — matches backend routes/commands.py CommandType enum exactly
+export type CommandType =
+  | "move_forward"
+  | "move_backward"
+  | "move_left"
+  | "move_right"
+  | "move_up"
+  | "move_down"
+  | "rotate_left"
+  | "rotate_right"
+  | "stop"
+  | "go_home"
+  | "gripper_open"
+  | "gripper_close";
+
 export type RobotOperationalStatus = "active" | "idle" | "paused" | "stopped" | "error";
 
 export type ScheduledTask = "home" | "retract" | "custom";


### PR DESCRIPTION
### 🛡️ VIBE Report

**1. Target Selected:**
`src/types/index.ts` / `src/services/robotApi.ts` — type centralization and `SequenceTask.action` type fix.

This was selected as the low-risk candidate because it is a purely type-layer change with no runtime logic altered. It directly addresses **TD-05** (Domain Types Defined Inline With No Shared Type Module) from the Module 1 Tech Debt Inventory. Scope is limited to three files: `src/types/index.ts`, `src/services/robotApi.ts`, and `src/components/ControlPanel.tsx`. No component behavior, API payloads, or business logic was changed.

---

**2. The Verification Event:**

The AI initially suggested merging `CommandType` and `RobotCommand` into a single unified type, reasoning that they appeared to be duplicates:

> *AI suggestion:* Remove `CommandType` entirely and replace all usages with `RobotCommand` from `src/types/index.ts`.

I rejected this after auditing the backend. Reading `backend/routes/commands.py` and `backend/routes/sequences.py` revealed these are two distinct enums serving two different endpoints:

- `/api/command` (direct control) accepts: `rotate_left`, `rotate_right`, `stop`, `move_left`, `move_right`
- `/api/sequence` (task sequences) accepts: `turn_left`, `turn_right`, `wait`

Merging them would have caused runtime 422 errors — the ControlPanel would have been sending `turn_left` to a backend endpoint that only recognizes `rotate_left`. Instead, both types are kept distinct with comments linking each to its backend enum, and `CommandType` was moved into `src/types/index.ts` so all types live in one module.

---

**3. Trust Boundary Established:**

Before this refactor:
- `SequenceTask.action` was typed as `string` — any arbitrary value could be dispatched toward robot hardware
- `CommandType` lived inside `src/services/robotApi.ts`, leaking type concerns into the service layer
- `ControlPanel.tsx` imported its core type from a service file rather than the type module

After this refactor:
- `SequenceTask.action` is typed as `RobotCommand` — the TypeScript compiler rejects any command string not in the backend-aligned allowlist at build time, before code reaches the robot
- All domain types live exclusively in `src/types/index.ts`
- The trust boundary is the type system itself: invalid commands cannot be constructed without a compile error

---

**4. Evidence of Execution:**

Screenshots attached showing the app running at `http://localhost:8081/` with UI rendering correctly across all tabs. Browser DevTools console shows no TypeScript or component errors. The connection error to the backend is expected — the Python server requires physical robot hardware to be present and is not part of this refactor.

<img width="1919" height="1079" alt="Screenshot 2026-03-23 164916" src="https://github.com/user-attachments/assets/f6586524-e684-48d3-b8ae-6cc2109b935d" />
<img width="1919" height="1079" alt="Screenshot 2026-03-23 164925" src="https://github.com/user-attachments/assets/3e663083-cdad-4249-aff4-11ac0ee46992" />
<img width="1919" height="1079" alt="Screenshot 2026-03-23 165115" src="https://github.com/user-attachments/assets/c57153f8-e6d9-44a5-8a08-00ac20c9351d" />

