### PR TITLE
refactor: extract robot command dispatcher and shared command metadata

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -4,40 +4,12 @@ import {
   ArrowUp, ArrowDown, ArrowLeft, ArrowRight,
   Square, Play, Pause, Home, ChevronUp, ChevronDown,
 } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
-import { useRobotStore } from "@/store/useRobotStore";
-import { useMutation } from "@tanstack/react-query";
-import { sendCommand } from "@/services/robotApi";
-import type { CommandType, RobotOperationalStatus } from "@/types";
+import { useRobotCommandDispatcher } from "@/hooks/useRobotCommandDispatcher";
+import { CONTROL_COMMANDS } from "@/constants/robotCommands";
 
 export const ControlPanel = () => {
-  const { toast } = useToast();
-  const { setStatus, setCurrentTask } = useRobotStore();
-
-  const mutation = useMutation({
-    mutationFn: (type: CommandType) => sendCommand(type),
-    onError: (error: Error) => {
-      toast({
-        title: "Command Failed",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
-  const handleControl = (
-    type: CommandType,
-    label: string,
-    status: RobotOperationalStatus = "active",
-  ) => {
-    // Optimistic store update so RobotStatus reflects the action immediately
-    setStatus(status);
-    setCurrentTask(label);
-    mutation.mutate(type);
-    toast({ title: "Command Sent", description: label });
-  };
-
-  const disabled = mutation.isPending;
+  const { dispatchCommand, isSending } = useRobotCommandDispatcher();
+  const disabled = isSending;
 
   return (
     <Card>
@@ -49,27 +21,27 @@ export const ControlPanel = () => {
         {/* Cartesian XY + rotation */}
         <div className="flex flex-col items-center gap-2">
           <Button variant="outline" size="icon" disabled={disabled} className="w-12 h-12"
-            onClick={() => handleControl("move_forward", "Moving Forward")}>
+            onClick={() => dispatchCommand(CONTROL_COMMANDS.moveForward)}>
             <ArrowUp className="h-5 w-5" />
           </Button>
 
           <div className="flex gap-2">
             <Button variant="outline" size="icon" disabled={disabled} className="w-12 h-12"
-              onClick={() => handleControl("rotate_left", "Rotating Left")}>
+              onClick={() => dispatchCommand(CONTROL_COMMANDS.rotateLeft)}>
               <ArrowLeft className="h-5 w-5" />
             </Button>
             <Button variant="outline" size="icon" disabled={disabled} className="w-12 h-12"
-              onClick={() => handleControl("stop", "Stopped", "stopped")}>
+              onClick={() => dispatchCommand(CONTROL_COMMANDS.stop)}>
               <Square className="h-5 w-5" />
             </Button>
             <Button variant="outline" size="icon" disabled={disabled} className="w-12 h-12"
-              onClick={() => handleControl("rotate_right", "Rotating Right")}>
+              onClick={() => dispatchCommand(CONTROL_COMMANDS.rotateRight)}>
               <ArrowRight className="h-5 w-5" />
             </Button>
           </div>
 
           <Button variant="outline" size="icon" disabled={disabled} className="w-12 h-12"
-            onClick={() => handleControl("move_backward", "Moving Backward")}>
+            onClick={() => dispatchCommand(CONTROL_COMMANDS.moveBackward)}>
             <ArrowDown className="h-5 w-5" />
           </Button>
         </div>
@@ -77,11 +49,11 @@ export const ControlPanel = () => {
         {/* Z axis */}
         <div className="flex justify-center gap-2">
           <Button variant="outline" size="sm" disabled={disabled} className="flex-1"
-            onClick={() => handleControl("move_up", "Moving Up")}>
+            onClick={() => dispatchCommand(CONTROL_COMMANDS.moveUp)}>
             <ChevronUp className="h-4 w-4 mr-1" /> Up
           </Button>
           <Button variant="outline" size="sm" disabled={disabled} className="flex-1"
-            onClick={() => handleControl("move_down", "Moving Down")}>
+            onClick={() => dispatchCommand(CONTROL_COMMANDS.moveDown)}>
             <ChevronDown className="h-4 w-4 mr-1" /> Down
           </Button>
         </div>
@@ -89,15 +61,15 @@ export const ControlPanel = () => {
         {/* Gripper + Home */}
         <div className="flex gap-2 pt-4 border-t">
           <Button className="flex-1" disabled={disabled}
-            onClick={() => handleControl("go_home", "Going Home", "active")}>
+            onClick={() => dispatchCommand(CONTROL_COMMANDS.goHome)}>
             <Home className="h-4 w-4 mr-2" /> Home
           </Button>
           <Button variant="secondary" className="flex-1" disabled={disabled}
-            onClick={() => handleControl("gripper_open", "Gripper Open")}>
+            onClick={() => dispatchCommand(CONTROL_COMMANDS.gripperOpen)}>
             <Play className="h-4 w-4 mr-2" /> Open
           </Button>
           <Button variant="secondary" className="flex-1" disabled={disabled}
-            onClick={() => handleControl("gripper_close", "Gripper Close")}>
+            onClick={() => dispatchCommand(CONTROL_COMMANDS.gripperClose)}>
             <Pause className="h-4 w-4 mr-2" /> Close
           </Button>
         </div>

--- a/src/components/TaskBuilder.tsx
+++ b/src/components/TaskBuilder.tsx
@@ -9,19 +9,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useTaskStore } from "@/store/useTaskStore";
 import { executeSequence } from "@/services/robotApi";
 import type { RobotCommand } from "@/types";
-
-const ACTION_LABELS: Record<RobotCommand, string> = {
-  move_forward:  "Move Forward",
-  move_backward: "Move Backward",
-  turn_left:     "Turn Left",
-  turn_right:    "Turn Right",
-  move_up:       "Move Up",
-  move_down:     "Move Down",
-  go_home:       "Go Home",
-  gripper_open:  "Open Gripper",
-  gripper_close: "Close Gripper",
-  wait:          "Wait",
-};
+import { TASK_ACTION_LABELS } from "@/constants/robotCommands";
 
 export const TaskBuilder = () => {
   const { tasks, addTask, removeTask, updateTask } = useTaskStore();
@@ -55,9 +43,9 @@ export const TaskBuilder = () => {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {(Object.keys(ACTION_LABELS) as RobotCommand[]).map((cmd) => (
+                    {(Object.keys(TASK_ACTION_LABELS) as RobotCommand[]).map((cmd) => (
                       <SelectItem key={cmd} value={cmd}>
-                        {ACTION_LABELS[cmd]}
+                        {TASK_ACTION_LABELS[cmd]}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/constants/robotCommands.ts
+++ b/src/constants/robotCommands.ts
@@ -1,0 +1,33 @@
+import type { CommandType, RobotCommand, RobotOperationalStatus } from "@/types";
+
+export interface ControlCommandConfig {
+  type: CommandType;
+  label: string;
+  status?: RobotOperationalStatus;
+}
+
+export const TASK_ACTION_LABELS: Record<RobotCommand, string> = {
+  move_forward: "Move Forward",
+  move_backward: "Move Backward",
+  turn_left: "Turn Left",
+  turn_right: "Turn Right",
+  move_up: "Move Up",
+  move_down: "Move Down",
+  go_home: "Go Home",
+  gripper_open: "Open Gripper",
+  gripper_close: "Close Gripper",
+  wait: "Wait",
+};
+
+export const CONTROL_COMMANDS = {
+  moveForward: { type: "move_forward", label: "Moving Forward" },
+  rotateLeft: { type: "rotate_left", label: "Rotating Left" },
+  stop: { type: "stop", label: "Stopped", status: "stopped" },
+  rotateRight: { type: "rotate_right", label: "Rotating Right" },
+  moveBackward: { type: "move_backward", label: "Moving Backward" },
+  moveUp: { type: "move_up", label: "Moving Up" },
+  moveDown: { type: "move_down", label: "Moving Down" },
+  goHome: { type: "go_home", label: "Going Home", status: "active" },
+  gripperOpen: { type: "gripper_open", label: "Gripper Open" },
+  gripperClose: { type: "gripper_close", label: "Gripper Close" },
+} as const satisfies Record<string, ControlCommandConfig>;

--- a/src/hooks/useRobotCommandDispatcher.ts
+++ b/src/hooks/useRobotCommandDispatcher.ts
@@ -1,0 +1,40 @@
+import { useMutation } from "@tanstack/react-query";
+import { useToast } from "@/hooks/use-toast";
+import { useRobotStore } from "@/store/useRobotStore";
+import { sendCommand } from "@/services/robotApi";
+import type { CommandType, RobotOperationalStatus } from "@/types";
+
+interface DispatchCommandParams {
+  type: CommandType;
+  label: string;
+  status?: RobotOperationalStatus;
+}
+
+export const useRobotCommandDispatcher = () => {
+  const { toast } = useToast();
+  const { setStatus, setCurrentTask } = useRobotStore();
+
+  const mutation = useMutation({
+    mutationFn: (type: CommandType) => sendCommand(type),
+    onError: (error: Error) => {
+      toast({
+        title: "Command Failed",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const dispatchCommand = ({ type, label, status = "active" }: DispatchCommandParams) => {
+    // Optimistic store update keeps RobotStatus aligned with the latest action.
+    setStatus(status);
+    setCurrentTask(label);
+    mutation.mutate(type);
+    toast({ title: "Command Sent", description: label });
+  };
+
+  return {
+    dispatchCommand,
+    isSending: mutation.isPending,
+  };
+};


### PR DESCRIPTION
1. Refactor Rationale (Architectural Debt)
Constraint/Problem:
Our initial Lovable.dev-style implementation had command execution behavior embedded directly inside UI components (ControlPanel and partially TaskBuilder). This mixed API calls, mutation lifecycle, optimistic store updates, and toast side effects with rendering logic.

Violation: This violated Single Responsibility Principle and created weak module boundaries.
Goal: Apply Separation of Concerns + Abstraction to decouple command orchestration from view components and remove duplicated command metadata.
Solution:
I extracted command behavior into a reusable hook and centralized command definitions in a shared constants module.

Old Structure:
src/components/ControlPanel.tsx handled UI + mutation + API + store updates + toasts
src/components/TaskBuilder.tsx duplicated action label mapping
New Structure:
src/hooks/useRobotCommandDispatcher.ts (encapsulated command dispatch logic)
src/constants/robotCommands.ts (shared command configs + labels)
src/components/ControlPanel.tsx (UI composition only)
src/components/TaskBuilder.tsx (reuses shared labels, no duplication)

2. AI Usage Summary (VIBE Log)
I used Cursor Chat/Composer to perform this refactor.

Prompt 1 (Planner):
"Audit the frontend for code smells and identify a structural refactor that improves modularity and abstraction without changing behavior."
Prompt 2 (Coder):
"Extract command orchestration from ControlPanel into a reusable hook and centralize command metadata in a shared constants file. Update TaskBuilder to consume shared labels."

My Verification:
Verified that optimistic state updates and toast behavior remained intact after extraction.
Ensured naming and module boundaries matched existing project conventions.
Confirmed the refactor preserved behavior and did not alter UI interactions.

**Proof**

<img width="1233" height="646" alt="Screenshot 2026-04-17 at 5 13 20 PM" src="https://github.com/user-attachments/assets/cf6fbffd-c7bb-4920-8564-be83483d1aa6" />