### PR TITLE
refactor(store): remove persist from robot store and add atomic updateFromFrame

### DIFF
--- a/src/hooks/useRobotSocket.ts
+++ b/src/hooks/useRobotSocket.ts
@@ -8,7 +8,7 @@ import { BRIDGE_WS_URL } from "@/services/robotApi";
  * Call once at the app root (Index.tsx).
  */
 export const useRobotSocket = () => {
-  const { setStatus, setConnection, setBattery, setCurrentTask } = useRobotStore();
+  const { updateFromFrame, setConnection } = useRobotStore();
 
   useEffect(() => {
     let ws: WebSocket;
@@ -25,10 +25,7 @@ export const useRobotSocket = () => {
       ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data as string);
-          setStatus(data.status);
-          setBattery(data.battery);
-          setConnection(data.connection);
-          setCurrentTask(data.currentTask);
+          updateFromFrame(data);
         } catch {
           // malformed frame — ignore
         }

--- a/src/store/useRobotStore.ts
+++ b/src/store/useRobotStore.ts
@@ -1,29 +1,31 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 import type { RobotStatus, RobotOperationalStatus, RobotConnectionStatus } from "@/types";
 
 interface RobotStore {
   robotStatus: RobotStatus;
+  // Atomic update for WebSocket frames — replaces 4 individual setters
+  updateFromFrame: (frame: Partial<RobotStatus>) => void;
+  // Individual setters kept for optimistic UI updates (e.g. ControlPanel)
   setStatus: (status: RobotOperationalStatus) => void;
   setConnection: (connection: RobotConnectionStatus) => void;
-  setBattery: (battery: number) => void;
   setCurrentTask: (task: string) => void;
 }
 
-export const useRobotStore = create<RobotStore>()(
-  persist(
-    (set) => ({
-      robotStatus: {
-        status: "idle",
-        battery: 85,
-        connection: "connected",
-        currentTask: "Idle",
-      },
-      setStatus: (status) => set((state) => ({ robotStatus: { ...state.robotStatus, status } })),
-      setConnection: (connection) => set((state) => ({ robotStatus: { ...state.robotStatus, connection } })),
-      setBattery: (battery) => set((state) => ({ robotStatus: { ...state.robotStatus, battery } })),
-      setCurrentTask: (task) => set((state) => ({ robotStatus: { ...state.robotStatus, currentTask: task } })),
-    }),
-    { name: "robot-status-storage" }
-  )
-);
+// Not persisted — live telemetry must always come from the WebSocket,
+// never from a stale localStorage snapshot.
+export const useRobotStore = create<RobotStore>()((set) => ({
+  robotStatus: {
+    status: "idle",
+    battery: 0,
+    connection: "disconnected",
+    currentTask: "",
+  },
+  updateFromFrame: (frame) =>
+    set((state) => ({ robotStatus: { ...state.robotStatus, ...frame } })),
+  setStatus: (status) =>
+    set((state) => ({ robotStatus: { ...state.robotStatus, status } })),
+  setConnection: (connection) =>
+    set((state) => ({ robotStatus: { ...state.robotStatus, connection } })),
+  setCurrentTask: (task) =>
+    set((state) => ({ robotStatus: { ...state.robotStatus, currentTask: task } })),
+}));


### PR DESCRIPTION
## 1. Refactor Rationale (Architectural Debt)

**Constraint/Problem:** The initial `useRobotStore` was wrapped with Zustand's `persist` middleware, which cached robot telemetry (battery, status, connection) to `localStorage`. It also exposed 4 separate setters (`setStatus`, `setBattery`, `setConnection`, `setCurrentTask`) that `useRobotSocket` called individually on every WebSocket frame.

- **Violation 1:** Persisting live telemetry violates the principle of truthfulness in state — on page reload, the UI would show stale data (e.g. `battery: 85%`, `status: "active"`) from a previous session instead of waiting for a fresh frame from the robot.
- **Violation 2:** Calling 4 separate setters per WebSocket message caused 4 sequential state updates (and re-renders) per frame, violating the principle of **atomicity** for a single logical operation.
- **Goal:** Apply **encapsulation** to hide the internal shape of `RobotStatus` from the socket hook, and remove persistence so telemetry is always live.

**Solution:** Added a single `updateFromFrame()` setter that merges a partial `RobotStatus` frame atomically, and removed the `persist` middleware entirely.

**Old Structure:**
- `useRobotStore.ts` — persisted to `localStorage`, 4 individual setters
- `useRobotSocket.ts` — called `setStatus`, `setBattery`, `setConnection`, `setCurrentTask` on every message

**New Structure:**
- `useRobotStore.ts` — no persistence, adds `updateFromFrame(frame)` for WebSocket updates, retains individual setters for optimistic UI (e.g. `ControlPanel`)
- `useRobotSocket.ts` — calls `updateFromFrame(data)` in a single line

---

## 2. AI Usage Summary (VIBE Log)

I used Claude Code to assist with this refactor.

- **Prompt 1 (Planner):** *"Look at useRobotStore and useRobotSocket. Identify any architectural problems with how WebSocket frames update the store."*
- **Prompt 2 (Coder):** *"Refactor useRobotStore to remove persist middleware and add an updateFromFrame atomic setter. Update useRobotSocket to use it."*
- **Human Verification (The "V" in VIBE):**
  - **Issue Found:** The AI's initial default state kept `battery: 85` and `connection: "connected"` — the same stale values that caused the original bug.
  - **Human Fix:** I changed the defaults to `battery: 0`, `connection: "disconnected"`, `currentTask: ""` so the UI correctly shows an unknown/disconnected state until the first real WebSocket frame arrives.
  - **Refinement:** I kept the individual setters (`setStatus`, `setCurrentTask`) rather than deleting them, because `ControlPanel` uses them for optimistic updates when a button is pressed — that's intentional and separate from live telemetry.

---

## 3. Verification & Testing

This was a pure refactor — the goal was **no regressions** in existing behavior.

**Manual Tests:**
- [x] Robot status updates in the UI when a WebSocket frame arrives
- [x] `ControlPanel` buttons still trigger optimistic status updates
- [x] On page reload, UI shows `disconnected` / empty state (not stale cached values)
- [x] No TypeScript errors (`setBattery` removed from interface cleanly)

**Evidence:**
- Confirmed `localStorage` no longer contains `robot-status-storage` key after reload
- Verified React DevTools shows single state update per WebSocket message instead of 4



<img width="1919" height="1079" alt="Screenshot 2026-03-23 181224" src="https://github.com/user-attachments/assets/5649bde1-d123-405f-aa89-85aeb3bc7bdf" />
<img width="1919" height="1079" alt="Screenshot 2026-03-23 180917" src="https://github.com/user-attachments/assets/09c3b431-3b08-4455-a218-25cb5bf803e7" />

